### PR TITLE
Changes to URI creation requests (POST/PUT on /uri/ endpoint)

### DIFF
--- a/demo/src/main/java/urlshortener/demo/controller/UriApi.java
+++ b/demo/src/main/java/urlshortener/demo/controller/UriApi.java
@@ -42,12 +42,11 @@ public interface UriApi {
             @ApiResponse(code = 201, message = "The URI redirection has been successfully created", response = URIItem.class),
             @ApiResponse(code = 400, message = "The URI was not reachable", response = URIItem.class)
     })
-    @RequestMapping(value = "/uri/{name}",
+    @RequestMapping(value = "/uri",
             produces = { "application/json" },
             consumes = { "application/json" },
-            method = RequestMethod.POST)
-    ResponseEntity<URIItem> createURIwithName(@ApiParam(value = "URI" ,required=true )  @Valid @RequestBody URICreate body,
-                                              @ApiParam(value = "actual name", required=true) @PathVariable("name") String name);
+            method = RequestMethod.PUT)
+    ResponseEntity<URIItem> createURIwithName(@ApiParam(value = "URI" ,required=true )  @Valid @RequestBody URICreate body);
 
 
     @ApiOperation(value = "Deletes an existing URI and its content.", nickname = "deleteURI", notes = "Remove a URI redirection ", tags={ "F0 - The app will short, storage and get URI&#39;s", })

--- a/demo/src/main/java/urlshortener/demo/controller/UriApi.java
+++ b/demo/src/main/java/urlshortener/demo/controller/UriApi.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import urlshortener.demo.domain.URICreate;
 import urlshortener.demo.domain.URIItem;
+import urlshortener.demo.domain.URIUpdate;
 
 import javax.validation.Valid;
 
@@ -21,7 +22,8 @@ public interface UriApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PUT)
-    ResponseEntity<URIItem> changeURI(@ApiParam(value = "Optional description in *Markdown*" ,required=true )  @Valid @RequestBody URICreate body,@ApiParam(value = "",required=true) @PathVariable("name") String name);
+    public ResponseEntity<URIItem> changeUri(@ApiParam(value = "update info", required=true )  @Valid @RequestBody URIUpdate body,
+                                                @ApiParam(value = "actual name", required=true) @PathVariable("name") String name);
 
 
     @ApiOperation(value = "Creates a new redirection", nickname = "createURI", notes = "Create a new URI redirection ", response = URIItem.class, tags={ "F0 - The app will short, storage and get URI&#39;s", })
@@ -32,8 +34,20 @@ public interface UriApi {
     @RequestMapping(value = "/uri",
         produces = { "application/json" }, 
         consumes = { "application/json" },
-        method = RequestMethod.PUT)
+        method = RequestMethod.POST)
     ResponseEntity<URIItem> createURI(@ApiParam(value = "URI" ,required=true )  @Valid @RequestBody URICreate body);
+
+    @ApiOperation(value = "Creates a new redirection with a custom name", nickname = "createURIWithName", notes = "Create a new URI redirection with a custom name", response = URIItem.class, tags={ "F0 - The app will short, storage and get URI&#39;s", })
+    @ApiResponses(value = {
+            @ApiResponse(code = 201, message = "The URI redirection has been successfully created", response = URIItem.class),
+            @ApiResponse(code = 400, message = "The URI was not reachable", response = URIItem.class)
+    })
+    @RequestMapping(value = "/uri/{name}",
+            produces = { "application/json" },
+            consumes = { "application/json" },
+            method = RequestMethod.POST)
+    ResponseEntity<URIItem> createURIwithName(@ApiParam(value = "URI" ,required=true )  @Valid @RequestBody URICreate body,
+                                              @ApiParam(value = "actual name", required=true) @PathVariable("name") String name);
 
 
     @ApiOperation(value = "Deletes an existing URI and its content.", nickname = "deleteURI", notes = "Remove a URI redirection ", tags={ "F0 - The app will short, storage and get URI&#39;s", })

--- a/demo/src/main/java/urlshortener/demo/controller/impl/UriApiController.java
+++ b/demo/src/main/java/urlshortener/demo/controller/impl/UriApiController.java
@@ -78,7 +78,7 @@ public class UriApiController implements UriApi {
 
     }
 
-    public ResponseEntity<URIItem> createNewUri(URICreate uri, String name) {
+    private ResponseEntity<URIItem> createNewUri(URICreate uri, String name) {
         CheckAlive c = new CheckAlive();
 
         ParameterUtils.checkParameter(name);
@@ -111,10 +111,9 @@ public class UriApiController implements UriApi {
         return createNewUri(body, Long.toHexString(uriService.getNextID()));
     }
 
-    public ResponseEntity<URIItem> createURIwithName(@ApiParam(value = "URI" ,required=true )  @Valid @RequestBody URICreate body,
-                                              @ApiParam(value = "actual name", required=true) @PathVariable("name") String name) {
+    public ResponseEntity<URIItem> createURIwithName(@ApiParam(value = "URI" ,required=true )  @Valid @RequestBody URICreate body) {
         String accept = request.getHeader("Accept");
-        return createNewUri(body, name);
+        return createNewUri(body, body.getName());
     }
 
     public ResponseEntity<Void> deleteURI(@ApiParam(value = "",required=true) @PathVariable("id") String id, @RequestHeader("URIHashPass") String hashpass) {

--- a/demo/src/main/java/urlshortener/demo/domain/URICreate.java
+++ b/demo/src/main/java/urlshortener/demo/domain/URICreate.java
@@ -17,6 +17,9 @@ public class URICreate   {
   @JsonProperty("uri")
   private String uri = null;
 
+  @JsonProperty("name")
+  private String name = "";
+
   public URICreate uri(String uri) {
     this.uri = uri;
     return this;
@@ -28,14 +31,31 @@ public class URICreate   {
   **/
   @ApiModelProperty(example = "https://google.es/", required = true, value = "")
   @NotNull
-
-
   public String getUri() {
     return uri;
   }
 
   public void setUri(String uri) {
     this.uri = uri;
+  }
+
+  /**
+   * Get uri
+   * @return uri
+   **/
+  @ApiModelProperty(example = "https://google.es/", required = true, value = "")
+  @NotNull
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public URICreate name(String name) {
+    this.name = name;
+    return this;
   }
 
 
@@ -48,20 +68,21 @@ public class URICreate   {
       return false;
     }
     URICreate urICreate = (URICreate) o;
-    return Objects.equals(this.uri, urICreate.uri);
+    return Objects.equals(this.uri, urICreate.uri) && Objects.equals(this.name, urICreate.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(uri);
+    return Objects.hash(uri,name);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class URICreate {\n");
-    
+
     sb.append("    uri: ").append(toIndentedString(uri)).append("\n");
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/demo/src/main/resources/static/js/app.js
+++ b/demo/src/main/resources/static/js/app.js
@@ -5,7 +5,7 @@ $(document).ready(
             event.preventDefault();
             var name = $("#customName").val();
             $.ajax({
-              type: "PUT",
+              type: "POST",
               url: "/uri/" + name,
               contentType: "application/json",
               data: JSON.stringify({"uri": $("#urlInput").val()}), // access in body

--- a/demo/src/main/resources/static/js/app.js
+++ b/demo/src/main/resources/static/js/app.js
@@ -4,11 +4,13 @@ $(document).ready(
           function (event) {
             event.preventDefault();
             var name = $("#customName").val();
+            var type = "";
+            if ($("#customName").val() === "") {type = "POST"} else {type = "PUT"}
             $.ajax({
-              type: "POST",
-              url: "/uri/" + name,
+              type: type,
+              url: "/uri",
               contentType: "application/json",
-              data: JSON.stringify({"uri": $("#urlInput").val()}), // access in body
+              data: JSON.stringify({"uri": $("#urlInput").val(), "name" : name}), // access in body
               success: function (msg) {
                 $("#shortenerResult").html(
                     "<div class='alert alert-success lead'><a target='_blank' href='"

--- a/demo/src/test/java/urlshortener/demo/controller/UriApiControllerIntegrationTest.java
+++ b/demo/src/test/java/urlshortener/demo/controller/UriApiControllerIntegrationTest.java
@@ -55,7 +55,7 @@ public class UriApiControllerIntegrationTest {
     public void createWithNameOK(){
         //Test 1: Create OK
         String uriName = "testURI";
-        ResponseEntity<URIItem> response = api.changeURI(correctURI, uriName);
+        ResponseEntity<URIItem> response = api.createURIwithName(correctURI.name(uriName));
         URIItem item = response.getBody();
 
         assertNotNull(item);
@@ -69,12 +69,12 @@ public class UriApiControllerIntegrationTest {
         String uriName = "testURI";
 
         try {
-            api.changeURI(invalidURI, uriName);
+            api.createURIwithName(invalidURI.name(uriName));
             fail();
         }catch (InvalidRequestParametersException ignored){ }
 
         try {
-            api.changeURI(emptyURI, uriName);
+            api.createURIwithName(emptyURI.name(uriName));
             fail();
         }catch (InvalidRequestParametersException ignored){ }
     }
@@ -84,12 +84,12 @@ public class UriApiControllerIntegrationTest {
         //Test 3: Create with invalid hash
 
         try {
-            api.changeURI(correctURI, null);
+            api.createURIwithName(correctURI.name(null));
             fail();
         }catch (InvalidRequestParametersException ignored){ }
 
         try {
-            api.changeURI(correctURI, "");
+            api.createURIwithName(correctURI.name(""));
             fail();
         }catch (InvalidRequestParametersException ignored){ }
     }

--- a/demo/src/test/java/urlshortener/demo/domain/URICreateTest.java
+++ b/demo/src/test/java/urlshortener/demo/domain/URICreateTest.java
@@ -33,16 +33,16 @@ public class URICreateTest {
     public void testURICreateCheckHashcode(){
         URICreate base = new URICreate().uri("abc");
 
-        assertEquals(96385, base.hashCode());
+        assertEquals(2987935, base.hashCode());
     }
 
     @Test
     public void testURICreateCheckToString(){
         URICreate base = new URICreate().uri("abc");
-        assertEquals("class URICreate {\n    uri: abc\n}", base.toString());
+        assertEquals("class URICreate {\n    uri: abc\n    name: \n}", base.toString());
 
         base = new URICreate().uri(null);
-        assertEquals("class URICreate {\n    uri: null\n}", base.toString());
+        assertEquals("class URICreate {\n    uri: null\n    name: \n}", base.toString());
 
     }
 

--- a/demo/src/test/java/urlshortener/demo/web/UriTests.java
+++ b/demo/src/test/java/urlshortener/demo/web/UriTests.java
@@ -138,6 +138,21 @@ public class UriTests {
                 .andExpect(status().isBadRequest());
     }
 
+    @Test
+    public void newNameURI() throws Exception {
+        URIItem uriItem = someURI();
+        String id = uriItem.getId();
+
+        doNothing().when(service).add(uriItem);
+        doReturn(uriItem).when(service).get(uriItem.getId());
+
+        String newName = "newName";
+        URIUpdate uriUpdate = (URIUpdate) new URIUpdate().newName("newName").hashpass(uriItem.getHashpass());
+
+        mockMvc.perform(put("/uri/{id}", id).contentType(MediaType.APPLICATION_JSON).content(mapObject(uriUpdate))).andDo(print())
+                .andExpect(status().isCreated());
+    }
+
     /*
      * Test DELETE /uri/{id}
      */

--- a/demo/src/test/java/urlshortener/demo/web/UriTests.java
+++ b/demo/src/test/java/urlshortener/demo/web/UriTests.java
@@ -13,6 +13,7 @@ import urlshortener.demo.controller.advice.BaseControllerAdvice;
 import urlshortener.demo.controller.impl.UriApiController;
 import urlshortener.demo.domain.URICreate;
 import urlshortener.demo.domain.URIItem;
+import urlshortener.demo.domain.URIUpdate;
 import urlshortener.demo.exception.CannotAddEntityException;
 import urlshortener.demo.repository.URIRepository;
 import urlshortener.demo.repository.QRRepository;
@@ -62,11 +63,10 @@ public class UriTests {
         //Test 1: Create OK
         doNothing().when(service).add(isA(URIItem.class));
 
-        URICreate uriCreate = someCorrectURICreate();
-        String id = "randomID";
-        mockMvc.perform(put("/uri/{id}", id).contentType(MediaType.APPLICATION_JSON).content(mapObject(uriCreate))).andDo(print())
+        URICreate uriCreate = someCorrectURICreate().name("randomID");
+        mockMvc.perform(put("/uri").contentType(MediaType.APPLICATION_JSON).content(mapObject(uriCreate))).andDo(print())
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id").value(id))
+                .andExpect(jsonPath("$.id").value("randomID"))
                 .andExpect(jsonPath("$.redirection").value(uriCreate.getUri()));
     }
 
@@ -107,7 +107,7 @@ public class UriTests {
         doNothing().when(service).add(isA(URIItem.class));
 
         URICreate uriCreate = someCorrectURICreate();
-        mockMvc.perform(put("/uri").contentType(MediaType.APPLICATION_JSON).content(mapObject(uriCreate))).andDo(print())
+        mockMvc.perform(post("/uri").contentType(MediaType.APPLICATION_JSON).content(mapObject(uriCreate))).andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.redirection").value(uriCreate.getUri()));
     }
@@ -119,11 +119,11 @@ public class UriTests {
         doNothing().when(service).add(isA(URIItem.class));
 
         URICreate uriCreate = someEmptyURICreate();
-        mockMvc.perform(put("/uri").contentType(MediaType.APPLICATION_JSON).content(mapObject(uriCreate))).andDo(print())
+        mockMvc.perform(post("/uri").contentType(MediaType.APPLICATION_JSON).content(mapObject(uriCreate))).andDo(print())
                 .andExpect(status().isBadRequest());
 
         uriCreate = someNullURICreate();
-        mockMvc.perform(put("/uri").contentType(MediaType.APPLICATION_JSON).content(mapObject(uriCreate))).andDo(print())
+        mockMvc.perform(post("/uri").contentType(MediaType.APPLICATION_JSON).content(mapObject(uriCreate))).andDo(print())
                 .andExpect(status().isBadRequest());
     }
 
@@ -134,7 +134,7 @@ public class UriTests {
         doThrow(CannotAddEntityException.class).when(service).add(isA(URIItem.class));
 
         URICreate uriCreate = someCorrectURICreate();
-        mockMvc.perform(put("/uri").contentType(MediaType.APPLICATION_JSON).content(mapObject(uriCreate))).andDo(print())
+        mockMvc.perform(post("/uri").contentType(MediaType.APPLICATION_JSON).content(mapObject(uriCreate))).andDo(print())
                 .andExpect(status().isBadRequest());
     }
 
@@ -244,5 +244,4 @@ public class UriTests {
         mockMvc.perform(get("/uri/{id}", item.getId())).andDo(print())
                 .andExpect(status().isTooManyRequests());
     }
-
 }


### PR DESCRIPTION
- **Create new URI:** POST /uri/ with a URICreate where "name" field is ignored.
- **Create new URI with name:** PUT /uri/ with a URICreate where "name" field isn't ignored.
- **Create new URI with name but with same redirection that existing one:** PUT /uri/{name} with a URIUpdate.